### PR TITLE
Close downstream connection on intercepted request

### DIFF
--- a/pyrox/server/proxyng.py
+++ b/pyrox/server/proxyng.py
@@ -189,6 +189,8 @@ class DownstreamHandler(ProxyHandler):
             self._preread_body = None
 
     def on_message_complete(self, is_chunked, keep_alive):
+        callback = self._downstream.close
+
         # Enable reading when we're ready later
         self._downstream.handle.disable_reading()
 
@@ -196,7 +198,7 @@ class DownstreamHandler(ProxyHandler):
             self._http_msg = HttpRequest()
 
         if self._intercepted:
-            self._downstream.write(self._response_tuple[0].to_bytes())
+            self._downstream.write(self._response_tuple[0].to_bytes(), callback)
         elif is_chunked or self._chunked:
             # Finish the last chunk.
             self._upstream.write(_CHUNK_CLOSE)


### PR DESCRIPTION
Intercepted requests get left open, causing hangs on the client. This adds a callback on downstream connections to ensure they are closed in such cases.

resolve #48 