### PR TITLE
Include .pyx files in package_data.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ setup(
     install_requires=read('tools/install_requires.txt'),
     test_suite='nose.collector',
     zip_safe=False,
+    package_data={
+        '': ['*.pyx']
+    },
     include_package_data=True,
     packages=find_packages(exclude=['*.tests']),
     ext_modules=compile_pyx())


### PR DESCRIPTION
This adds .pyx files to packages, so pyrox can be installed from local wheels.